### PR TITLE
Move proxy target to variable

### DIFF
--- a/.github/workflows/build-and-deploy-to-cloud-run.yml
+++ b/.github/workflows/build-and-deploy-to-cloud-run.yml
@@ -16,6 +16,7 @@ env:
   IMAGE: gateway
   REGISTRY_HOSTNAME: us.gcr.io
   REVERSE_PROXY_API_TARGET: ${{ secrets.REVERSE_PROXY_API_TARGET }}
+  DNS_RESOLVER: ${{ secrets.DNS_RESOLVER }}
 
 jobs:
   setup-build-publish-deploy:
@@ -48,7 +49,8 @@ jobs:
             -t "$REGISTRY_HOSTNAME/$GOOGLE_PROJECT/$IMAGE:latest" \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF" \
-            --build-arg REVERSE_PROXY_API_TARGET="$REVERSE_PROXY_API_TARGET" .
+            --build-arg REVERSE_PROXY_API_TARGET="$REVERSE_PROXY_API_TARGET" \
+            --build-arg DNS_RESOLVER="$DNS_RESOLVER" .
 
       # Push the Docker image to Google Container Registry
       - name: Publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM nginx:latest
 
 ARG REVERSE_PROXY_API_TARGET=replace-me;
+ARG DNS_RESOLVER=replace-me;
 
 ADD static /usr/share/nginx/html
 ADD nginx.conf.template /opt/nginx.conf.template
 
-RUN envsubst < /opt/nginx.conf.template > /etc/nginx/nginx.conf
+RUN envsubst '$REVERSE_PROXY_API_TARGET,$DNS_RESOLVER' < /opt/nginx.conf.template > /etc/nginx/nginx.conf
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
         context: ./
         args:
           REVERSE_PROXY_API_TARGET: ${REVERSE_PROXY_API_TARGET}
+          DNS_RESOLVER: ${DNS_RESOLVER}
     ports:
       - '80:80'
       - '443:80'

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -10,6 +10,8 @@ http {
   server {
     server_name _;
     absolute_redirect off;
+    resolver ${DNS_RESOLVER} valid=15s;
+    set $target ${REVERSE_PROXY_API_TARGET};
 
     location /favicon.ico {
         root /usr/share/nginx/html/img;
@@ -17,12 +19,12 @@ http {
 
     location /api/ {
         proxy_ssl_server_name on;
-        proxy_pass ${REVERSE_PROXY_API_TARGET}/api/;
+        proxy_pass $target/api/;
     }
 
     location /grafana/ {
         proxy_ssl_server_name on;
-        proxy_pass ${REVERSE_PROXY_API_TARGET}/grafana/;
+        proxy_pass $target/grafana/;
     }
   }
 }


### PR DESCRIPTION
Apparently when nginx resolves a DNS, it caches the IP. This causes outages if the upstream IP address changes

Setting the proxy target as a variable prevents this: https://www.nginx.com/blog/dns-service-discovery-nginx-plus/